### PR TITLE
Dockerfile for hpe3par_simulator

### DIFF
--- a/extra/hpe3par_simulator/Dockerfile
+++ b/extra/hpe3par_simulator/Dockerfile
@@ -1,0 +1,16 @@
+FROM library/python:3
+
+ARG FLASK_PORT=5001
+
+WORKDIR /usr/src
+
+RUN git clone https://github.com/HewlettPackard/hpe3par_python_sdk.git \
+    && cd hpe3par_python_sdk \
+    && pip install . \
+    && pip install flask
+
+EXPOSE $FLASK_PORT
+
+VOLUME [ "/usr/src" ]
+
+CMD [ "python", "hpe3par_python_sdk/test/HPE3ParMockServer_flask.py -port $FLASK_PORT" ]


### PR DESCRIPTION
Dockerfile for a simple container starting the 3par simulator.

Usage:

cd extra/hpe3par_simulator
docker build . -t hpe/3parsimulator:latest
docker run --rm -ti hpe/3parsimulator:latest

Also would be nice if you would integrate that in the autobuild feature for docker hub?
